### PR TITLE
Handle PointCloud2 messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,9 @@ find_package(laser_geometry REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_sensor_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common io)
+find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
+find_package(pcl_ros REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
@@ -43,8 +44,19 @@ if(BUILD_TESTING)
 endif()
 
 add_executable(laser_merger2 src/laser_merger2.cpp src/laser_merger2_main.cpp)
-target_include_directories(laser_merger2 PUBLIC include)
-ament_target_dependencies(laser_merger2 rclcpp tf2_ros tf2_sensor_msgs tf2_geometry_msgs PCL pcl_conversions laser_geometry sensor_msgs)
+target_include_directories(laser_merger2 PUBLIC include ${PCL_INCLUDE_DIRS})
+ament_target_dependencies(
+  laser_merger2
+  rclcpp
+  tf2_ros
+  tf2_sensor_msgs
+  tf2_geometry_msgs
+  PCL
+  pcl_conversions
+  pcl_ros
+  laser_geometry
+  sensor_msgs
+)
 
 install(TARGETS
   laser_merger2

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ git clone https://github.com/qaz9517532846/laser_merger2.git
 | ---                                | ---                                                               | 
 | target_frame                       | target tf frame(Default: "base_link").                            |
 | scan_topics                        | List of topics on which to read the laser scans                   |
+| point_cloud_topics                 | List of topics on which to read the point clouds (PointCloud2)    |
 | transform_tolerance                | TF transform tolerance.                                           |
 | rate                               | Publish rate(Hz).                                                 |
 | queue_size                         | Subscribe queue size.                                             |
@@ -53,6 +54,8 @@ For example:
 ``` bash
 $ ros2 launch laser_merger2 laser_merger.launch.py target_frame:=base scan_topics:="[/lidar, /lidar2]" output_pointcloud_topic:=/merged_pcl
 ```
+
+Note that laser_merger2 can merge `LaserScan` and/or `PointCloud2` messages, depending on the topics you provide with the `scan_topics` and `point_cloud_topics` arguments.
 
 ### Result
 

--- a/include/laser_merger2/laser_merger2.h
+++ b/include/laser_merger2/laser_merger2.h
@@ -44,7 +44,9 @@ class laser_merger2 : public rclcpp::Node
 
   private:
     void scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr scan);
+    void pointCloudCallback(const sensor_msgs::msg::PointCloud2::SharedPtr cloud);
     std::vector<SCAN_POINT_t> scantoPointXYZ(const sensor_msgs::msg::LaserScan::SharedPtr scan);
+    std::vector<SCAN_POINT_t> pointCloudtoPointXYZ(const sensor_msgs::msg::PointCloud2::SharedPtr cloud);
     Eigen::Matrix4d Rotate3Z(double rad);
     Eigen::Matrix4d ConvertTransMatrix(geometry_msgs::msg::TransformStamped trans);
     uint32_t rgb_to_uint32(uint8_t r, uint8_t g, uint8_t b);
@@ -58,11 +60,13 @@ class laser_merger2 : public rclcpp::Node
     std::unique_ptr<tf2_ros::TransformListener> tf2_listener_;
 
     std::vector<rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr> laser_sub;
+    std::vector<rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr> point_cloud_sub;
 
     std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> pclPub_;
     std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::LaserScan>> scanPub_;
 
     std::map<std::string, sensor_msgs::msg::LaserScan::SharedPtr> scanBuffer;
+    std::map<std::string, sensor_msgs::msg::PointCloud2::SharedPtr> pointCloudBuffer;
 
     std::thread subscription_listener_thread_;
     std::atomic_bool alive_{true};
@@ -76,6 +80,7 @@ class laser_merger2 : public rclcpp::Node
     std::shared_ptr<rclcpp::Rate> rosRate;
     std::string target_frame_;
     std::vector<std::string> scan_topics;
+    std::vector<std::string> point_cloud_topics;
     double tolerance_;
     double rate_;
     int input_queue_size_;

--- a/launch/laser_merger.launch.py
+++ b/launch/laser_merger.launch.py
@@ -11,7 +11,12 @@ from launch.substitutions import ThisLaunchFileDir
 
 def generate_launch_description():
     target_frame = LaunchConfiguration('target_frame', default='base_link')
-    scan_topics = LaunchConfiguration('scan_topics', default=["/sick_s30b/laser/scan0", "/sick_s30b/laser/scan1"])
+    # We set the topic arrays to a default value of an array containing an empty string, because
+    # ROS2 does not yet allow empty sequences for both launch arguments (cf https://github.com/ros2/launch_ros/blob/humble/launch_ros/launch_ros/utilities/evaluate_parameters.py#L50)
+    # and rclcpp parameters (cf https://github.com/ros2/rclcpp/issues/1955).
+    # In the code, we simply ignore empty topic names.
+    scan_topics = LaunchConfiguration('scan_topics', default="['']")
+    point_cloud_topics = LaunchConfiguration('point_cloud_topics', default="['']")
     transform_tolerance = LaunchConfiguration('transform_tolerance', default=0.1)
     rate = LaunchConfiguration('rate', default=30.0)
     queue_size = LaunchConfiguration('queue_size', default=10)
@@ -35,6 +40,7 @@ def generate_launch_description():
             output='screen',
             parameters=[{'target_frame': target_frame},
                         {'scan_topics': scan_topics},
+                        {'point_cloud_topics': point_cloud_topics},
                         {'transform_tolerance': transform_tolerance},
                         {'rate': rate},
                         {'queue_size': queue_size},

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>PCL</depend>
   <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -151,6 +151,7 @@ std::vector<SCAN_POINT_t> laser_merger2::scantoPointXYZ(const sensor_msgs::msg::
 		SCAN_POINT_t point;
 		point.x = scanPos(0, 0);
 		point.y = scanPos(1, 0);
+        point.z = scanPos(2, 0);
         if (has_intensity)
             point.intensity = scan->intensities[i];
 		points.emplace_back(point);

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -6,11 +6,13 @@
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include <boost/bind.hpp>
+#include <pcl_ros/transforms.hpp>
 
 laser_merger2::laser_merger2() : Node("laser_merger2")
 {
     this->declare_parameter<std::string>("target_frame", "base_link");
     this->declare_parameter<std::vector<std::string>>("scan_topics", { "/sick_s30b/laser/scan0", "/sick_s30b/laser/scan1" });
+    this->declare_parameter<std::vector<std::string>>("point_cloud_topics", { "/sick_s30b/laser/points0", "/sick_s30b/laser/points1" });
     this->declare_parameter<double>("transform_tolerance", 0.01);
     this->declare_parameter<double>("rate", 30.0);
     this->declare_parameter<int>("queue_size", 20);
@@ -26,6 +28,7 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
 
     this->get_parameter("target_frame", target_frame_);
     this->get_parameter("scan_topics", scan_topics);
+    this->get_parameter("point_cloud_topics", point_cloud_topics);
     this->get_parameter("transform_tolerance", tolerance_);
     this->get_parameter("rate", rate_);
     this->get_parameter("queue_size", input_queue_size_);
@@ -51,13 +54,30 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
         tf2_->setCreateTimerInterface(timer_interface);
         tf2_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf2_);
 
-        size_t laser_num = scan_topics.size();
-        laser_sub.resize(laser_num);
+        size_t num_scan_sub = scan_topics.size();
+        laser_sub.resize(num_scan_sub);
         for(const std::string &scan_topic : scan_topics)
         {
+            if (scan_topic.empty())
+                continue;
+            RCLCPP_INFO(this->get_logger(), "Subscribing to topic %s, expecting LaserScan messages", scan_topic.c_str());
             laser_sub.push_back(this->create_subscription<sensor_msgs::msg::LaserScan>(scan_topic, input_queue_size_, [this](const sensor_msgs::msg::LaserScan::SharedPtr msg)
                 {
                     scanCallback(msg);
+                }
+            ));
+        }
+
+        size_t num_cloud_sub = point_cloud_topics.size();
+        point_cloud_sub.resize(num_cloud_sub);
+        for(const std::string &cloud_topic : point_cloud_topics)
+        {
+            if (cloud_topic.empty())
+                continue;
+            RCLCPP_INFO(this->get_logger(), "Subscribing to topic %s, expecting PointCloud2 messages", cloud_topic.c_str());
+            point_cloud_sub.push_back(this->create_subscription<sensor_msgs::msg::PointCloud2>(cloud_topic, input_queue_size_, [this](const sensor_msgs::msg::PointCloud2::SharedPtr msg)
+                {
+                    pointCloudCallback(msg);
                 }
             ));
         }
@@ -79,6 +99,14 @@ void laser_merger2::scanCallback(const sensor_msgs::msg::LaserScan::SharedPtr sc
 
     laserTime = scan->header.stamp;
     scanBuffer[scan->header.frame_id] = scan;
+}
+
+void laser_merger2::pointCloudCallback(const sensor_msgs::msg::PointCloud2::SharedPtr cloud)
+{
+    std::lock_guard<std::mutex> lock(nodeMutex_);
+
+    laserTime = cloud->header.stamp;
+    pointCloudBuffer[cloud->header.frame_id] = cloud;
 }
 
 Eigen::Matrix4d laser_merger2::Rotate3Z(double rad)
@@ -154,6 +182,42 @@ std::vector<SCAN_POINT_t> laser_merger2::scantoPointXYZ(const sensor_msgs::msg::
         point.z = scanPos(2, 0);
         if (has_intensity)
             point.intensity = scan->intensities[i];
+		points.emplace_back(point);
+	}
+	
+	return points;
+}
+
+std::vector<SCAN_POINT_t> laser_merger2::pointCloudtoPointXYZ(const sensor_msgs::msg::PointCloud2::SharedPtr cloud)
+{
+    std::vector<SCAN_POINT_t> points;
+
+    sensor_msgs::msg::PointCloud2 transformed_cloud;
+    if (!pcl_ros::transformPointCloud(target_frame_, *cloud, transformed_cloud, *tf2_.get())) {
+        RCLCPP_WARN(this->get_logger(), "Could not transform point cloud");
+        return points;
+    }
+
+    sensor_msgs::PointCloud2ConstIterator<float> iter_x(transformed_cloud, "x");
+    sensor_msgs::PointCloud2ConstIterator<float> iter_y(transformed_cloud, "y");
+    sensor_msgs::PointCloud2ConstIterator<float> iter_z(transformed_cloud, "z");
+
+    bool has_intensity = std::find_if(cloud->fields.begin(), cloud->fields.end(), [](const auto &field) {
+        return field.name == "intensity";
+    }) != cloud->fields.end();
+    sensor_msgs::PointCloud2ConstIterator<float> iter_intensity(transformed_cloud, "intensity");
+
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
+        SCAN_POINT_t point;
+        point.x = *iter_x;
+        point.y = *iter_y;
+        point.z = *iter_z;
+
+        if (has_intensity) {
+            point.intensity = *iter_intensity;
+            ++iter_intensity;
+        }
+
 		points.emplace_back(point);
 	}
 	
@@ -291,6 +355,13 @@ void laser_merger2::laser_merge()
                 points.insert(points.end(), scanPoints.begin(), scanPoints.end());
             }
             scanBuffer.clear();
+
+            for(const auto& cloud : pointCloudBuffer)
+            {
+                auto cloudPoints = pointCloudtoPointXYZ(cloud.second);
+                points.insert(points.end(), cloudPoints.begin(), cloudPoints.end());
+            }
+            pointCloudBuffer.clear();
         }
 
         if (!points.empty()) {


### PR DESCRIPTION
Until then, only `LaserScan` messages were supported as input. Now `PointCloud2` are also supported. You can read both types if you want, or just one of them, depending on what you pass as launch parameters.

I changed the default value of the `scan_topics` parameter in the launch file. So now if you launch the node without any parameter it won't automatically subscribe to the _/sick_s30b/laser/scan0_ and _/sick_s30b/laser/scan1_ topics anymore. But I don't think that is too much of a problem, and it allows to simply ignore the `scan_topics` parameter if one doesn't want to subscribe to `LaserScan` topics, which is more handy than having to explicitly clear it like `scan_topics:="['']"`.

I also fixed the z value which was not handled, mainly because you worked with 2D LiDARs I guess.