### PR TITLE
Feature: Add QoS profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ $ git clone https://github.com/qaz9517532846/laser_merger2.git
 | ---                                | ---                                                               | 
 | target_frame                       | target tf frame(Default: "base_link").                            |
 | scan_topics                        | List of topics on which to read the laser scans                   |
+| scan_reliability_policies          | List of QoS reliability policies per scan topic                   |
 | point_cloud_topics                 | List of topics on which to read the point clouds (PointCloud2)    |
+| point_cloud_reliability_policies   | List of QoS reliability policies per point cloud topic            |
 | transform_tolerance                | TF transform tolerance.                                           |
 | rate                               | Publish rate(Hz).                                                 |
 | queue_size                         | Subscribe queue size.                                             |

--- a/README.md
+++ b/README.md
@@ -29,8 +29,14 @@ $ git clone https://github.com/qaz9517532846/laser_merger2.git
 | target_frame                       | target tf frame(Default: "base_link").                            |
 | scan_topics                        | List of topics on which to read the laser scans                   |
 | scan_reliability_policies          | List of QoS reliability policies per scan topic                   |
+| scan_history_policies              | List of QoS history policies per scan topic                       |
+| scan_depths                        | List of QoS depths per scan topic                                 |
+| scan_durability_policies           | List of QoS durability policies per scan topic                    |
 | point_cloud_topics                 | List of topics on which to read the point clouds (PointCloud2)    |
 | point_cloud_reliability_policies   | List of QoS reliability policies per point cloud topic            |
+| point_cloud_history_policies       | List of QoS history policies per point cloud topic                |
+| point_cloud_depths                 | List of QoS depths per point cloud topic                          |
+| point_cloud_durability_policies    | List of QoS durability policies per point cloud topic             |
 | transform_tolerance                | TF transform tolerance.                                           |
 | rate                               | Publish rate(Hz).                                                 |
 | queue_size                         | Subscribe queue size.                                             |

--- a/README.md
+++ b/README.md
@@ -19,36 +19,44 @@ $ git clone https://github.com/qaz9517532846/laser_merger2.git
 
 ------
 
-| Topic                              | Description                                                       |
-| ---                                | ---                                                               |
-| pointcloud                         | Merger pointcloud2 msg.                                           |
-| scan                               | Merger laser scan msg.                                            ||
+| Topic                                     | Description                                                       |
+| ---                                       | ---                                                               |
+| pointcloud                                | Merger pointcloud2 msg.                                           |
+| scan                                      | Merger laser scan msg.                                            ||
 
-| Parameter                          | Description                                                       |
-| ---                                | ---                                                               | 
-| target_frame                       | target tf frame(Default: "base_link").                            |
-| scan_topics                        | List of topics on which to read the laser scans                   |
-| scan_reliability_policies          | List of QoS reliability policies per scan topic                   |
-| scan_history_policies              | List of QoS history policies per scan topic                       |
-| scan_depths                        | List of QoS depths per scan topic                                 |
-| scan_durability_policies           | List of QoS durability policies per scan topic                    |
-| point_cloud_topics                 | List of topics on which to read the point clouds (PointCloud2)    |
-| point_cloud_reliability_policies   | List of QoS reliability policies per point cloud topic            |
-| point_cloud_history_policies       | List of QoS history policies per point cloud topic                |
-| point_cloud_depths                 | List of QoS depths per point cloud topic                          |
-| point_cloud_durability_policies    | List of QoS durability policies per point cloud topic             |
-| transform_tolerance                | TF transform tolerance.                                           |
-| rate                               | Publish rate(Hz).                                                 |
-| max_range                          | Merge laser scan max range.                                       |
-| min_range                          | Merge laser scan min range.                                       |
-| max_angle                          | Merge laser scan max angle.                                       |
-| min_angle                          | Merge laser scan min angle.                                       |
-| scan_time                          | Merge laser scan scan time.                                       |
-| angle_increment                    | Merge laser scan angle increment.                                 |
-| inf_epsilon                        | inf epsilon value.                                                |
-| use_inf                            | use inf.                                                          |
-| output_pointcloud_topic            | Name of the output merged point cloud topic                       |
-| output_scan_topic                  | Name of the output merged scan topic                              ||
+| Parameter                                 | Description                                                       |
+| ---                                       | ---                                                               | 
+| target_frame                              | target tf frame(Default: "base_link").                            |
+| scan_topics                               | List of topics on which to read the laser scans                   |
+| scan_reliability_policies                 | List of QoS reliability policies per scan topic                   |
+| scan_history_policies                     | List of QoS history policies per scan topic                       |
+| scan_depths                               | List of QoS depths per scan topic                                 |
+| scan_durability_policies                  | List of QoS durability policies per scan topic                    |
+| point_cloud_topics                        | List of topics on which to read the point clouds (PointCloud2)    |
+| point_cloud_reliability_policies          | List of QoS reliability policies per point cloud topic            |
+| point_cloud_history_policies              | List of QoS history policies per point cloud topic                |
+| point_cloud_depths                        | List of QoS depths per point cloud topic                          |
+| point_cloud_durability_policies           | List of QoS durability policies per point cloud topic             |
+| output_scan_reliability_policy            | QoS reliability policy for the output scan topic                  |
+| output_scan_history_policy                | QoS history policy for the output scan topic                      |
+| output_scan_depth                         | QoS depth for the output scan topic                               |
+| output_scan_durability_policy             | QoS durability policy for the scan topic                          |
+| output_point_cloud_reliability_policy     | QoS reliability policy for the output point cloud topic           |
+| output_point_cloud_history_policy         | QoS history policy for the output point cloud topic               |
+| output_point_cloud_depth                  | QoS depth for the output point cloud topic                        |
+| output_point_cloud_durability_policy      | QoS durability policy for the point cloud topic                   |
+| transform_tolerance                       | TF transform tolerance.                                           |
+| rate                                      | Publish rate(Hz).                                                 |
+| max_range                                 | Merge laser scan max range.                                       |
+| min_range                                 | Merge laser scan min range.                                       |
+| max_angle                                 | Merge laser scan max angle.                                       |
+| min_angle                                 | Merge laser scan min angle.                                       |
+| scan_time                                 | Merge laser scan scan time.                                       |
+| angle_increment                           | Merge laser scan angle increment.                                 |
+| inf_epsilon                               | inf epsilon value.                                                |
+| use_inf                                   | use inf.                                                          |
+| output_pointcloud_topic                   | Name of the output merged point cloud topic                       |
+| output_scan_topic                         | Name of the output merged scan topic                              ||
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ $ git clone https://github.com/qaz9517532846/laser_merger2.git
 | point_cloud_durability_policies    | List of QoS durability policies per point cloud topic             |
 | transform_tolerance                | TF transform tolerance.                                           |
 | rate                               | Publish rate(Hz).                                                 |
-| queue_size                         | Subscribe queue size.                                             |
 | max_range                          | Merge laser scan max range.                                       |
 | min_range                          | Merge laser scan min range.                                       |
 | max_angle                          | Merge laser scan max angle.                                       |

--- a/include/laser_merger2/laser_merger2.h
+++ b/include/laser_merger2/laser_merger2.h
@@ -76,6 +76,7 @@ class laser_merger2 : public rclcpp::Node
     std::shared_ptr<rclcpp::Rate> rosRate;
     std::string target_frame_;
     std::vector<std::string> scan_topics;
+    std::vector<std::string> qos_profiles;
     double tolerance_;
     double rate_;
     int input_queue_size_;

--- a/include/laser_merger2/laser_merger2.h
+++ b/include/laser_merger2/laser_merger2.h
@@ -81,11 +81,16 @@ class laser_merger2 : public rclcpp::Node
     std::string target_frame_;
     std::vector<std::string> scan_topics;
     std::vector<std::string> scan_reliability_policies;
+    std::vector<std::string> scan_history_policies;
+    std::vector<int64_t> scan_depths;
+    std::vector<std::string> scan_durability_policies;
     std::vector<std::string> point_cloud_topics;
     std::vector<std::string> point_cloud_reliability_policies;
+    std::vector<std::string> point_cloud_history_policies;
+    std::vector<int64_t> point_cloud_depths;
+    std::vector<std::string> point_cloud_durability_policies;
     double tolerance_;
     double rate_;
-    int input_queue_size_;
     int subscription_count;
 
     double max_range;

--- a/include/laser_merger2/laser_merger2.h
+++ b/include/laser_merger2/laser_merger2.h
@@ -90,15 +90,15 @@ class laser_merger2 : public rclcpp::Node
     std::vector<int64_t> point_cloud_depths;
     std::vector<std::string> point_cloud_durability_policies;
 
-    std::string  output_scan_reliability_policy_;
-    std::string  output_scan_history_policy_;
-    int64_t      output_scan_depth_;
-    std::string  output_scan_durability_policy_;
+    std::string output_scan_reliability_policy_;
+    std::string output_scan_history_policy_;
+    int64_t output_scan_depth_;
+    std::string output_scan_durability_policy_;
 
-    std::string  output_pointcloud_reliability_policy_;
-    std::string  output_pointcloud_history_policy_;
-    int64_t      output_pointcloud_depth_;
-    std::string  output_pointcloud_durability_policy_;
+    std::string output_pointcloud_reliability_policy_;
+    std::string output_pointcloud_history_policy_;
+    int64_t output_pointcloud_depth_;
+    std::string output_pointcloud_durability_policy_;
 
     double tolerance_;
     double rate_;

--- a/include/laser_merger2/laser_merger2.h
+++ b/include/laser_merger2/laser_merger2.h
@@ -80,9 +80,9 @@ class laser_merger2 : public rclcpp::Node
     std::shared_ptr<rclcpp::Rate> rosRate;
     std::string target_frame_;
     std::vector<std::string> scan_topics;
-    std::vector<std::string> scan_qos_profiles;
+    std::vector<std::string> scan_reliability_policies;
     std::vector<std::string> point_cloud_topics;
-    std::vector<std::string> point_cloud_qos_profiles;
+    std::vector<std::string> point_cloud_reliability_policies;
     double tolerance_;
     double rate_;
     int input_queue_size_;

--- a/include/laser_merger2/laser_merger2.h
+++ b/include/laser_merger2/laser_merger2.h
@@ -89,6 +89,17 @@ class laser_merger2 : public rclcpp::Node
     std::vector<std::string> point_cloud_history_policies;
     std::vector<int64_t> point_cloud_depths;
     std::vector<std::string> point_cloud_durability_policies;
+
+    std::string  output_scan_reliability_policy_;
+    std::string  output_scan_history_policy_;
+    int64_t      output_scan_depth_;
+    std::string  output_scan_durability_policy_;
+
+    std::string  output_pointcloud_reliability_policy_;
+    std::string  output_pointcloud_history_policy_;
+    int64_t      output_pointcloud_depth_;
+    std::string  output_pointcloud_durability_policy_;
+
     double tolerance_;
     double rate_;
     int subscription_count;

--- a/launch/laser_merger.launch.py
+++ b/launch/laser_merger.launch.py
@@ -12,6 +12,7 @@ from launch.substitutions import ThisLaunchFileDir
 def generate_launch_description():
     target_frame = LaunchConfiguration('target_frame', default='base_link')
     scan_topics = LaunchConfiguration('scan_topics', default=["/sick_s30b/laser/scan0", "/sick_s30b/laser/scan1"])
+    qos_profiles = LaunchConfiguration('qos_profiles', default=["reliable", "reliable"])
     transform_tolerance = LaunchConfiguration('transform_tolerance', default=0.1)
     rate = LaunchConfiguration('rate', default=30.0)
     queue_size = LaunchConfiguration('queue_size', default=10)
@@ -35,6 +36,7 @@ def generate_launch_description():
             output='screen',
             parameters=[{'target_frame': target_frame},
                         {'scan_topics': scan_topics},
+                        {'qos_profiles': qos_profiles},
                         {'transform_tolerance': transform_tolerance},
                         {'rate': rate},
                         {'queue_size': queue_size},

--- a/launch/laser_merger.launch.py
+++ b/launch/laser_merger.launch.py
@@ -16,9 +16,9 @@ def generate_launch_description():
     # and rclcpp parameters (cf https://github.com/ros2/rclcpp/issues/1955).
     # In the code, we simply ignore empty topic names.
     scan_topics = LaunchConfiguration('scan_topics', default="['']")
-    scan_qos_profiles = LaunchConfiguration('scan_qos_profiles', default=["reliable", "reliable"])
+    scan_reliability_policies = LaunchConfiguration('scan_reliability_policies', default="['']")
     point_cloud_topics = LaunchConfiguration('point_cloud_topics', default="['']")
-    point_cloud_qos_profiles = LaunchConfiguration('point_cloud_qos_profiles', default=["reliable", "reliable"])
+    point_cloud_reliability_policies = LaunchConfiguration('point_cloud_reliability_policies', default="['']")
     transform_tolerance = LaunchConfiguration('transform_tolerance', default=0.1)
     rate = LaunchConfiguration('rate', default=30.0)
     queue_size = LaunchConfiguration('queue_size', default=10)
@@ -42,9 +42,9 @@ def generate_launch_description():
             output='screen',
             parameters=[{'target_frame': target_frame},
                         {'scan_topics': scan_topics},
-                        {'scan_qos_profiles': scan_qos_profiles},
+                        {'scan_reliability_policies': scan_reliability_policies},
                         {'point_cloud_topics': point_cloud_topics},
-                        {'point_cloud_qos_profiles': point_cloud_qos_profiles},
+                        {'point_cloud_reliability_policies': point_cloud_reliability_policies},
                         {'transform_tolerance': transform_tolerance},
                         {'rate': rate},
                         {'queue_size': queue_size},

--- a/launch/laser_merger.launch.py
+++ b/launch/laser_merger.launch.py
@@ -17,11 +17,16 @@ def generate_launch_description():
     # In the code, we simply ignore empty topic names.
     scan_topics = LaunchConfiguration('scan_topics', default="['']")
     scan_reliability_policies = LaunchConfiguration('scan_reliability_policies', default="['']")
+    scan_history_policies = LaunchConfiguration('scan_history_policies', default="['']")
+    scan_depths = LaunchConfiguration('scan_depths', default="[0]")
+    scan_durability_policies = LaunchConfiguration('scan_durability_policies', default="['']")
     point_cloud_topics = LaunchConfiguration('point_cloud_topics', default="['']")
     point_cloud_reliability_policies = LaunchConfiguration('point_cloud_reliability_policies', default="['']")
+    point_cloud_history_policies = LaunchConfiguration('point_cloud_history_policies', default="['']")
+    point_cloud_depths = LaunchConfiguration('point_cloud_depths', default="[0]")
+    point_cloud_durability_policies = LaunchConfiguration('point_cloud_durability_policies', default="['']")
     transform_tolerance = LaunchConfiguration('transform_tolerance', default=0.1)
     rate = LaunchConfiguration('rate', default=30.0)
-    queue_size = LaunchConfiguration('queue_size', default=10)
     max_range = LaunchConfiguration('max_range', default=30.0)
     min_range = LaunchConfiguration('min_range', default=0.06)
     max_angle = LaunchConfiguration('max_angle', default=3.141592654)
@@ -43,11 +48,16 @@ def generate_launch_description():
             parameters=[{'target_frame': target_frame},
                         {'scan_topics': scan_topics},
                         {'scan_reliability_policies': scan_reliability_policies},
+                        {'scan_history_policies': scan_history_policies},
+                        {'scan_depths': scan_depths},
+                        {'scan_durability_policies': scan_durability_policies},
                         {'point_cloud_topics': point_cloud_topics},
                         {'point_cloud_reliability_policies': point_cloud_reliability_policies},
+                        {'point_cloud_history_policies': point_cloud_history_policies},
+                        {'point_cloud_depths': point_cloud_depths},
+                        {'point_cloud_durability_policies': point_cloud_durability_policies},
                         {'transform_tolerance': transform_tolerance},
                         {'rate': rate},
-                        {'queue_size': queue_size},
                         {'max_range': max_range},
                         {'min_range': min_range},
                         {'max_angle': max_angle},

--- a/launch/laser_merger.launch.py
+++ b/launch/laser_merger.launch.py
@@ -25,6 +25,14 @@ def generate_launch_description():
     point_cloud_history_policies = LaunchConfiguration('point_cloud_history_policies', default="['']")
     point_cloud_depths = LaunchConfiguration('point_cloud_depths', default="[0]")
     point_cloud_durability_policies = LaunchConfiguration('point_cloud_durability_policies', default="['']")
+    output_scan_reliability_policy = LaunchConfiguration('output_scan_reliability_policy', default="''")
+    output_scan_history_policy = LaunchConfiguration('output_scan_history_policy', default="''")
+    output_scan_depth = LaunchConfiguration('output_scan_depth', default="0")
+    output_scan_durability_policy = LaunchConfiguration('output_scan_durability_policy', default="''")
+    output_point_cloud_reliability_policy = LaunchConfiguration('output_scan_reliability_policy', default="''")
+    output_point_cloud_history_policy = LaunchConfiguration('output_point_cloud_history_policy', default="''")
+    output_point_cloud_depth = LaunchConfiguration('output_point_cloud_depth', default="0")
+    output_point_cloud_durability_policy = LaunchConfiguration('output_point_cloud_durability_policy', default="''")
     transform_tolerance = LaunchConfiguration('transform_tolerance', default=0.1)
     rate = LaunchConfiguration('rate', default=30.0)
     max_range = LaunchConfiguration('max_range', default=30.0)
@@ -56,6 +64,14 @@ def generate_launch_description():
                         {'point_cloud_history_policies': point_cloud_history_policies},
                         {'point_cloud_depths': point_cloud_depths},
                         {'point_cloud_durability_policies': point_cloud_durability_policies},
+                        {'output_scan_reliability_policy': output_scan_reliability_policy},
+                        {'output_scan_history_policy': output_scan_history_policy},
+                        {'output_scan_depth': output_scan_depth},
+                        {'output_scan_durability_policy': output_scan_durability_policy},
+                        {'output_point_cloud_reliability_policy': output_point_cloud_reliability_policy},
+                        {'output_point_cloud_history_policy': output_point_cloud_history_policy},
+                        {'output_point_cloud_depth': output_point_cloud_depth},
+                        {'output_point_cloud_durability_policy': output_point_cloud_durability_policy},
                         {'transform_tolerance': transform_tolerance},
                         {'rate': rate},
                         {'max_range': max_range},

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -211,35 +211,46 @@ void laser_merger2::ConvertPointCloud2(std::vector<SCAN_POINT_t> points)
                                          "z", 1, sensor_msgs::msg::PointField::FLOAT32,
                                          "intensity", 1, sensor_msgs::msg::PointField::FLOAT32);
                                          // "rgb", 1, sensor_msgs::msg::PointField::FLOAT32);
-    }
-    else
-    {
-        modifier.setPointCloud2Fields(4, "x", 1, sensor_msgs::msg::PointField::FLOAT32,
-                                         "y", 1, sensor_msgs::msg::PointField::FLOAT32,
-                                         "z", 1, sensor_msgs::msg::PointField::FLOAT32);
-    }
 
-    sensor_msgs::PointCloud2Iterator<float> iter_x(*pclMsg, "x");
-    sensor_msgs::PointCloud2Iterator<float> iter_y(*pclMsg, "y");
-    sensor_msgs::PointCloud2Iterator<float> iter_z(*pclMsg, "z");
-    sensor_msgs::PointCloud2Iterator<float> iter_intensity(*pclMsg, "intensity");
-    //sensor_msgs::PointCloud2Iterator<float> iter_rgb(*pclMsg, "rgb");
+        sensor_msgs::PointCloud2Iterator<float> iter_x(*pclMsg, "x");
+        sensor_msgs::PointCloud2Iterator<float> iter_y(*pclMsg, "y");
+        sensor_msgs::PointCloud2Iterator<float> iter_z(*pclMsg, "z");
+        sensor_msgs::PointCloud2Iterator<float> iter_intensity(*pclMsg, "intensity");
+        // sensor_msgs::PointCloud2Iterator<float> iter_rgb(*pclMsg, "rgb");
 
-    for(size_t i = 0; i < pclMsg->width; i++)
-    {
-        //uint32_t rgb_value = rgb_to_uint32(255, 0, 0);
-        *iter_x = points[i].x;
-        *iter_y = points[i].y;
-        *iter_z = points[i].z;
-        if (has_intensity)
+        for(size_t i = 0; i < pclMsg->width; i++)
+        {
+            //uint32_t rgb_value = rgb_to_uint32(255, 0, 0);
+            *iter_x = points[i].x;
+            *iter_y = points[i].y;
+            *iter_z = points[i].z;
             *iter_intensity = points[i].intensity.value();
 
-        /*float* rgb_ptr = reinterpret_cast<float*>(&rgb_value);
-        *iter_rgb = *rgb_ptr;*/
+            /*float* rgb_ptr = reinterpret_cast<float*>(&rgb_value);
+            *iter_rgb = *rgb_ptr;*/
 
-        ++iter_x; ++iter_y; ++iter_z; //++iter_rgb;
-        if (has_intensity)
+            ++iter_x; ++iter_y; ++iter_z; //++iter_rgb;
             ++iter_intensity;
+        }
+
+    } else {
+        modifier.setPointCloud2Fields(3, "x", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                         "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                         "z", 1, sensor_msgs::msg::PointField::FLOAT32);
+
+
+        sensor_msgs::PointCloud2Iterator<float> iter_x(*pclMsg, "x");
+        sensor_msgs::PointCloud2Iterator<float> iter_y(*pclMsg, "y");
+        sensor_msgs::PointCloud2Iterator<float> iter_z(*pclMsg, "z");
+
+        for(size_t i = 0; i < pclMsg->width; i++)
+        {
+            *iter_x = points[i].x;
+            *iter_y = points[i].y;
+            *iter_z = points[i].z;
+
+            ++iter_x; ++iter_y; ++iter_z;
+        }
     }
 
     pclPub_->publish(*pclMsg);

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -10,7 +10,7 @@
 laser_merger2::laser_merger2() : Node("laser_merger2")
 {
     this->declare_parameter<std::string>("target_frame", "base_link");
-    this->declare_parameter<std::vector<std::string>>("scan_topics", { "/sick_s30b/laser/scan0", "/sick_s30b/laser/scan1" });
+    this->declare_parameter<std::vector<std::string>>("scan_topics");
     this->declare_parameter<double>("transform_tolerance", 0.01);
     this->declare_parameter<double>("rate", 30.0);
     this->declare_parameter<int>("queue_size", 20);

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -25,12 +25,12 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->declare_parameter<std::string>("output_scan_reliability_policy", "reliable");
     this->declare_parameter<std::string>("output_scan_history_policy", "KeepLast");
     this->declare_parameter<int64_t>("output_scan_depth", 20);
-    this->declare_parameter<std::string>("output_scan_durability_policy","volatile");
+    this->declare_parameter<std::string>("output_scan_durability_policy", "volatile");
 
     this->declare_parameter<std::string>("output_pointcloud_reliability_policy", "reliable");
     this->declare_parameter<std::string>("output_pointcloud_history_policy", "KeepLast");
     this->declare_parameter<int64_t>("output_pointcloud_depth", 20);
-    this->declare_parameter<std::string>("output_pointcloud_durability_policy","volatile");
+    this->declare_parameter<std::string>("output_pointcloud_durability_policy", "volatile");
 
     this->declare_parameter<double>("transform_tolerance", 0.01);
     this->declare_parameter<double>("rate", 30.0);
@@ -77,9 +77,6 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->get_parameter("angle_increment", angle_increment);
     this->get_parameter("inf_epsilon", inf_epsilon);
     this->get_parameter("use_inf", use_inf);
-
-    // pclPub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud", rclcpp::SystemDefaultsQoS());
-    // scanPub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SystemDefaultsQoS());
 
     {
         // PointCloud publisher

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -22,6 +22,16 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->declare_parameter<std::vector<int64_t>>("point_cloud_depths", {20,20});
     this->declare_parameter<std::vector<std::string>>("point_cloud_durability_policies", {"volatile","volatile"});
 
+    this->declare_parameter<std::string>("output_scan_reliability_policy", "reliable");
+    this->declare_parameter<std::string>("output_scan_history_policy", "KeepLast");
+    this->declare_parameter<int64_t>("output_scan_depth", 20);
+    this->declare_parameter<std::string>("output_scan_durability_policy","volatile");
+
+    this->declare_parameter<std::string>("output_pointcloud_reliability_policy", "reliable");
+    this->declare_parameter<std::string>("output_pointcloud_history_policy", "KeepLast");
+    this->declare_parameter<int64_t>("output_pointcloud_depth", 20);
+    this->declare_parameter<std::string>("output_pointcloud_durability_policy","volatile");
+
     this->declare_parameter<double>("transform_tolerance", 0.01);
     this->declare_parameter<double>("rate", 30.0);
 
@@ -45,6 +55,17 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->get_parameter("point_cloud_history_policies", point_cloud_history_policies);
     this->get_parameter("point_cloud_depths", point_cloud_depths);
     this->get_parameter("point_cloud_durability_policies", point_cloud_durability_policies);
+
+    this->get_parameter("output_pointcloud_reliability_policy",output_pointcloud_reliability_policy_);
+    this->get_parameter("output_pointcloud_history_policy", output_pointcloud_history_policy_);
+    this->get_parameter("output_pointcloud_depth", output_pointcloud_depth_);
+    this->get_parameter("output_pointcloud_durability_policy", output_pointcloud_durability_policy_);
+
+    this->get_parameter("output_scan_reliability_policy",output_scan_reliability_policy_);
+    this->get_parameter("output_scan_history_policy", output_scan_history_policy_);
+    this->get_parameter("output_scan_depth", output_scan_depth_);
+    this->get_parameter("output_scan_durability_policy", output_scan_durability_policy_);
+
     this->get_parameter("transform_tolerance", tolerance_);
     this->get_parameter("rate", rate_);
 
@@ -57,8 +78,38 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->get_parameter("inf_epsilon", inf_epsilon);
     this->get_parameter("use_inf", use_inf);
 
-    pclPub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud", rclcpp::SystemDefaultsQoS());
-    scanPub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SystemDefaultsQoS());
+    // pclPub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud", rclcpp::SystemDefaultsQoS());
+    // scanPub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SystemDefaultsQoS());
+
+    {
+        // PointCloud publisher
+        std::string rel = output_pointcloud_reliability_policy_.empty() ? "reliable" : output_pointcloud_reliability_policy_;
+        std::string hist = output_pointcloud_history_policy_.empty() ? "KeepLast" : output_pointcloud_history_policy_;
+        size_t depth = output_pointcloud_depth_ > 0 ? static_cast<size_t>(output_pointcloud_depth_) : 20;
+        std::string dur = output_pointcloud_durability_policy_.empty() ? "volatile" : output_pointcloud_durability_policy_;
+
+        rclcpp::QoS qos(depth);
+        if (hist == "KeepAll") qos.keep_all(); else qos.keep_last(depth);
+        if (rel == "reliable") qos.reliable(); else qos.best_effort();
+        if (dur == "transient_local") qos.transient_local(); else qos.durability_volatile();
+
+        pclPub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud", qos);
+    }
+
+    {
+        // Scan publisher
+        std::string rel = output_scan_reliability_policy_.empty() ? "reliable" : output_scan_reliability_policy_;
+        std::string hist = output_scan_history_policy_.empty() ? "KeepLast" : output_scan_history_policy_;
+        size_t depth = output_scan_depth_ > 0 ? static_cast<size_t>(output_scan_depth_) : 20;
+        std::string dur = output_scan_durability_policy_.empty() ? "volatile" : output_scan_durability_policy_;
+
+        rclcpp::QoS qos(depth);
+        if (hist == "KeepAll") qos.keep_all(); else qos.keep_last(depth);
+        if (rel == "reliable") qos.reliable(); else qos.best_effort();
+        if (dur == "transient_local") qos.transient_local(); else qos.durability_volatile();
+
+        scanPub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", qos);
+    }
 
     rosRate = std::make_shared<rclcpp::Rate>(rate_);
 

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -82,7 +82,7 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
                 scan_qos_profile.reliable();
             }
 
-            RCLCPP_DEBUG(this->get_logger(), "Subscribing to scan topic '%s' with QoS profile '%s'", scan_topic.c_str(), scan_reliability_policy_str.c_str());
+            RCLCPP_DEBUG(this->get_logger(), "Subscribing to scan topic '%s' with QoS reliability policy '%s'", scan_topic.c_str(), scan_reliability_policy_str.c_str());
             laser_sub[i] = this->create_subscription<sensor_msgs::msg::LaserScan>(
                 scan_topic,
                 scan_qos_profile,
@@ -116,7 +116,7 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
                 point_cloud_qos_profile.reliable();
             }
 
-            RCLCPP_DEBUG(this->get_logger(), "Subscribing to point cloud topic '%s' with QoS profile '%s'", point_cloud_topic.c_str(), point_cloud_reliability_policy_str.c_str());
+            RCLCPP_DEBUG(this->get_logger(), "Subscribing to point cloud topic '%s' with QoS reliability policy '%s'", point_cloud_topic.c_str(), point_cloud_reliability_policy_str.c_str());
             point_cloud_sub[i] = this->create_subscription<sensor_msgs::msg::PointCloud2>(
                 point_cloud_topic,
                 point_cloud_qos_profile,

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -12,9 +12,9 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
 {
     this->declare_parameter<std::string>("target_frame", "base_link");
     this->declare_parameter<std::vector<std::string>>("scan_topics", { "/sick_s30b/laser/scan0", "/sick_s30b/laser/scan1" });
-    this->declare_parameter<std::vector<std::string>>("scan_qos_profiles", { "reliable", "reliable" });
+    this->declare_parameter<std::vector<std::string>>("scan_reliability_policies", { "reliable", "reliable" });
     this->declare_parameter<std::vector<std::string>>("point_cloud_topics", { "/sick_s30b/laser/points0", "/sick_s30b/laser/points1" });
-    this->declare_parameter<std::vector<std::string>>("point_cloud_qos_profiles", { "reliable", "reliable" });
+    this->declare_parameter<std::vector<std::string>>("point_cloud_reliability_policies", { "reliable", "reliable" });
     this->declare_parameter<double>("transform_tolerance", 0.01);
     this->declare_parameter<double>("rate", 30.0);
     this->declare_parameter<int>("queue_size", 20);
@@ -30,9 +30,9 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
 
     this->get_parameter("target_frame", target_frame_);
     this->get_parameter("scan_topics", scan_topics);
-    this->get_parameter("scan_qos_profiles", scan_qos_profiles);
+    this->get_parameter("scan_reliability_policies", scan_reliability_policies);
     this->get_parameter("point_cloud_topics", point_cloud_topics);
-    this->get_parameter("point_cloud_qos_profiles", point_cloud_qos_profiles);
+    this->get_parameter("point_cloud_reliability_policies", point_cloud_reliability_policies);
     this->get_parameter("transform_tolerance", tolerance_);
     this->get_parameter("rate", rate_);
     this->get_parameter("queue_size", input_queue_size_);
@@ -63,26 +63,26 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
         for (size_t i = 0; i < laser_num; ++i)
         {
             const std::string &scan_topic = scan_topics[i];
-            std::string scan_qos_profile_str;
+            std::string scan_reliability_policy_str;
             rclcpp::QoS scan_qos_profile = rclcpp::SensorDataQoS();
 
-            if (i < scan_qos_profiles.size()) {
-                if (scan_qos_profiles[i] == "reliable") {
-                    scan_qos_profile_str = "reliable";
+            if (i < scan_reliability_policies.size()) {
+                if (scan_reliability_policies[i] == "reliable") {
+                    scan_reliability_policy_str = "reliable";
                     scan_qos_profile.reliable();
-                } else if (scan_qos_profiles[i] == "besteffort") {
-                    scan_qos_profile_str = "besteffort";
+                } else if (scan_reliability_policies[i] == "besteffort") {
+                    scan_reliability_policy_str = "besteffort";
                     scan_qos_profile.best_effort();
                 } else {
-                    scan_qos_profile_str = "reliable";
+                    scan_reliability_policy_str = "reliable";
                     scan_qos_profile.reliable();
                 }
             } else {
-                scan_qos_profile_str = "reliable";
+                scan_reliability_policy_str = "reliable";
                 scan_qos_profile.reliable();
             }
 
-            RCLCPP_DEBUG(this->get_logger(), "Subscribing to scan topic '%s' with QoS profile '%s'", scan_topic.c_str(), scan_qos_profile_str.c_str());
+            RCLCPP_DEBUG(this->get_logger(), "Subscribing to scan topic '%s' with QoS profile '%s'", scan_topic.c_str(), scan_reliability_policy_str.c_str());
             laser_sub[i] = this->create_subscription<sensor_msgs::msg::LaserScan>(
                 scan_topic,
                 scan_qos_profile,
@@ -97,26 +97,26 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
         for (size_t i = 0; i < point_cloud_num; ++i)
         {
             const std::string &point_cloud_topic = point_cloud_topics[i];
-            std::string point_cloud_qos_profile_str;
+            std::string point_cloud_reliability_policy_str;
             rclcpp::QoS point_cloud_qos_profile = rclcpp::SensorDataQoS();
 
-            if (i < point_cloud_qos_profiles.size()) {
-                if (point_cloud_qos_profiles[i] == "reliable") {
-                    point_cloud_qos_profile_str = "reliable";
+            if (i < point_cloud_reliability_policies.size()) {
+                if (point_cloud_reliability_policies[i] == "reliable") {
+                    point_cloud_reliability_policy_str = "reliable";
                     point_cloud_qos_profile.reliable();
-                } else if (point_cloud_qos_profiles[i] == "besteffort") {
-                    point_cloud_qos_profile_str = "besteffort";
+                } else if (point_cloud_reliability_policies[i] == "besteffort") {
+                    point_cloud_reliability_policy_str = "besteffort";
                     point_cloud_qos_profile.best_effort();
                 } else {
-                    point_cloud_qos_profile_str = "reliable";
+                    point_cloud_reliability_policy_str = "reliable";
                     point_cloud_qos_profile.reliable();
                 }
             } else {
-                point_cloud_qos_profile_str = "reliable";
+                point_cloud_reliability_policy_str = "reliable";
                 point_cloud_qos_profile.reliable();
             }
 
-            RCLCPP_DEBUG(this->get_logger(), "Subscribing to point cloud topic '%s' with QoS profile '%s'", point_cloud_topic.c_str(), point_cloud_qos_profile_str.c_str());
+            RCLCPP_DEBUG(this->get_logger(), "Subscribing to point cloud topic '%s' with QoS profile '%s'", point_cloud_topic.c_str(), point_cloud_reliability_policy_str.c_str());
             point_cloud_sub[i] = this->create_subscription<sensor_msgs::msg::PointCloud2>(
                 point_cloud_topic,
                 point_cloud_qos_profile,

--- a/src/laser_merger2.cpp
+++ b/src/laser_merger2.cpp
@@ -13,11 +13,17 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->declare_parameter<std::string>("target_frame", "base_link");
     this->declare_parameter<std::vector<std::string>>("scan_topics", { "/sick_s30b/laser/scan0", "/sick_s30b/laser/scan1" });
     this->declare_parameter<std::vector<std::string>>("scan_reliability_policies", { "reliable", "reliable" });
+    this->declare_parameter<std::vector<std::string>>("scan_history_policies", {"KeepLast","KeepLast"});
+    this->declare_parameter<std::vector<int64_t>>("scan_depths", {20,20});
+    this->declare_parameter<std::vector<std::string>>("scan_durability_policies", {"volatile","volatile"});
     this->declare_parameter<std::vector<std::string>>("point_cloud_topics", { "/sick_s30b/laser/points0", "/sick_s30b/laser/points1" });
     this->declare_parameter<std::vector<std::string>>("point_cloud_reliability_policies", { "reliable", "reliable" });
+    this->declare_parameter<std::vector<std::string>>("point_cloud_history_policies", {"KeepLast","KeepLast"});
+    this->declare_parameter<std::vector<int64_t>>("point_cloud_depths", {20,20});
+    this->declare_parameter<std::vector<std::string>>("point_cloud_durability_policies", {"volatile","volatile"});
+
     this->declare_parameter<double>("transform_tolerance", 0.01);
     this->declare_parameter<double>("rate", 30.0);
-    this->declare_parameter<int>("queue_size", 20);
 
     this->declare_parameter<double>("max_range", 30.0);
     this->declare_parameter<double>("min_range", 0.06);
@@ -31,11 +37,16 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->get_parameter("target_frame", target_frame_);
     this->get_parameter("scan_topics", scan_topics);
     this->get_parameter("scan_reliability_policies", scan_reliability_policies);
+    this->get_parameter("scan_history_policies", scan_history_policies);
+    this->get_parameter("scan_depths", scan_depths);
+    this->get_parameter("scan_durability_policies", scan_durability_policies);
     this->get_parameter("point_cloud_topics", point_cloud_topics);
     this->get_parameter("point_cloud_reliability_policies", point_cloud_reliability_policies);
+    this->get_parameter("point_cloud_history_policies", point_cloud_history_policies);
+    this->get_parameter("point_cloud_depths", point_cloud_depths);
+    this->get_parameter("point_cloud_durability_policies", point_cloud_durability_policies);
     this->get_parameter("transform_tolerance", tolerance_);
     this->get_parameter("rate", rate_);
-    this->get_parameter("queue_size", input_queue_size_);
 
     this->get_parameter("max_range", max_range);
     this->get_parameter("min_range", min_range);
@@ -46,8 +57,8 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
     this->get_parameter("inf_epsilon", inf_epsilon);
     this->get_parameter("use_inf", use_inf);
 
-    pclPub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud", input_queue_size_);
-    scanPub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", input_queue_size_);
+    pclPub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud", rclcpp::SystemDefaultsQoS());
+    scanPub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SystemDefaultsQoS());
 
     rosRate = std::make_shared<rclcpp::Rate>(rate_);
 
@@ -58,70 +69,78 @@ laser_merger2::laser_merger2() : Node("laser_merger2")
 
     if (!target_frame_.empty())
     {
-        size_t laser_num = scan_topics.size();
-        laser_sub.resize(laser_num);
-        for (size_t i = 0; i < laser_num; ++i)
-        {
-            const std::string &scan_topic = scan_topics[i];
-            std::string scan_reliability_policy_str;
-            rclcpp::QoS scan_qos_profile = rclcpp::SensorDataQoS();
+        // Scan subscriptions
+        laser_sub.resize(scan_topics.size());
+        for (size_t i = 0; i < scan_topics.size(); ++i) {
+            const auto &topic = scan_topics[i];
+            if (topic.empty()) continue;  // skip empty topic names
 
-            if (i < scan_reliability_policies.size()) {
-                if (scan_reliability_policies[i] == "reliable") {
-                    scan_reliability_policy_str = "reliable";
-                    scan_qos_profile.reliable();
-                } else if (scan_reliability_policies[i] == "besteffort") {
-                    scan_reliability_policy_str = "besteffort";
-                    scan_qos_profile.best_effort();
-                } else {
-                    scan_reliability_policy_str = "reliable";
-                    scan_qos_profile.reliable();
-                }
-            } else {
-                scan_reliability_policy_str = "reliable";
-                scan_qos_profile.reliable();
-            }
+            // Reliability
+            std::string rel = (i < scan_reliability_policies.size() ? scan_reliability_policies[i] : "reliable");
+            if (rel.empty()) rel = "reliable";
+            // History
+            std::string hist = (i < scan_history_policies.size() ? scan_history_policies[i] : "KeepLast");
+            if (hist.empty()) rel = "KeepLast";
+            // Depth
+            int64_t raw_depth = (i < scan_depths.size() ? scan_depths[i] : 20);
+            size_t depth = raw_depth > 0 ? static_cast<size_t>(raw_depth) : 20;
+            // Durability
+            std::string dur = (i < scan_durability_policies.size() ? scan_durability_policies[i] : "volatile");
+            if (dur.empty()) rel = "volatile";
 
-            RCLCPP_DEBUG(this->get_logger(), "Subscribing to scan topic '%s' with QoS reliability policy '%s'", scan_topic.c_str(), scan_reliability_policy_str.c_str());
+            // Build QoS
+            rclcpp::QoS qos(depth);
+            if (hist == "KeepAll") qos.keep_all(); else qos.keep_last(depth);
+            if (rel == "reliable") qos.reliable(); else qos.best_effort();
+            if (dur == "transient_local") qos.transient_local(); else qos.durability_volatile();
+
+            RCLCPP_DEBUG(
+                this->get_logger(),
+                "Subscribing to laser scan '%s' with QoS profile: Reliability Policy='%s' History Policy='%s' Depth='%zu' Durability Policy='%s'",
+                scan_topics[i].c_str(), rel.c_str(), hist.c_str(), depth, dur.c_str()
+            );
+
             laser_sub[i] = this->create_subscription<sensor_msgs::msg::LaserScan>(
-                scan_topic,
-                scan_qos_profile,
-                [this](const sensor_msgs::msg::LaserScan::SharedPtr msg) {
-                    scanCallback(msg);
-                }
+                scan_topics[i], qos,
+                [this](const sensor_msgs::msg::LaserScan::SharedPtr msg) { scanCallback(msg); }
             );
         }
 
-        size_t point_cloud_num = point_cloud_topics.size();
-        point_cloud_sub.resize(point_cloud_num);
-        for (size_t i = 0; i < point_cloud_num; ++i)
-        {
-            const std::string &point_cloud_topic = point_cloud_topics[i];
-            std::string point_cloud_reliability_policy_str;
-            rclcpp::QoS point_cloud_qos_profile = rclcpp::SensorDataQoS();
+        // PointCloud subscriptions
+        point_cloud_sub.resize(point_cloud_topics.size());
+        for (size_t i = 0; i < point_cloud_topics.size(); ++i) {
+            const auto &topic = point_cloud_topics[i];
+            if (topic.empty()) continue;  // skip empty topic names
 
-            if (i < point_cloud_reliability_policies.size()) {
-                if (point_cloud_reliability_policies[i] == "reliable") {
-                    point_cloud_reliability_policy_str = "reliable";
-                    point_cloud_qos_profile.reliable();
-                } else if (point_cloud_reliability_policies[i] == "besteffort") {
-                    point_cloud_reliability_policy_str = "besteffort";
-                    point_cloud_qos_profile.best_effort();
-                } else {
-                    point_cloud_reliability_policy_str = "reliable";
-                    point_cloud_qos_profile.reliable();
-                }
-            } else {
-                point_cloud_reliability_policy_str = "reliable";
-                point_cloud_qos_profile.reliable();
-            }
+            // Reliability
+            std::string rel = (i < point_cloud_reliability_policies.size() ? point_cloud_reliability_policies[i] : "reliable");
+            if (rel.empty()) rel = "reliable";
+            // History
+            std::string hist = (i < point_cloud_history_policies.size() ? point_cloud_history_policies[i] : "KeepLast");
+            if (hist.empty()) rel = "KeepLast";
+            // Depth
+            int64_t raw_depth = (i < scan_depths.size() ? scan_depths[i] : 20);
+            size_t depth = raw_depth > 0 ? static_cast<size_t>(raw_depth) : 20;
+            // Durability
+            std::string dur = (i < point_cloud_durability_policies.size() ? point_cloud_durability_policies[i] : "volatile");
+            if (dur.empty()) rel = "volatile";
 
-            RCLCPP_DEBUG(this->get_logger(), "Subscribing to point cloud topic '%s' with QoS reliability policy '%s'", point_cloud_topic.c_str(), point_cloud_reliability_policy_str.c_str());
+            // Build QoS
+            rclcpp::QoS qos(depth);
+            if (hist == "KeepAll")  qos.keep_all(); else qos.keep_last(depth);
+            if (rel == "reliable")  qos.reliable(); else qos.best_effort();
+            if (dur == "transient_local") qos.transient_local(); else qos.durability_volatile();
+
+            RCLCPP_DEBUG(
+                this->get_logger(),
+                "Subscribing to '%s' with QoS profile: Reliability Policy='%s' History Policy='%s' Depth='%zu' Durability Policy='%s'",
+                point_cloud_topics[i].c_str(), rel.c_str(), hist.c_str(), depth, dur.c_str()
+            );
+
             point_cloud_sub[i] = this->create_subscription<sensor_msgs::msg::PointCloud2>(
-                point_cloud_topic,
-                point_cloud_qos_profile,
+                point_cloud_topics[i], qos,
                 [this](const sensor_msgs::msg::PointCloud2::SharedPtr msg) {
-                    pointCloudCallback(msg);
+                pointCloudCallback(msg);
                 }
             );
         }


### PR DESCRIPTION
This PR will:

1. Add an option to provide a list of QoS profiles to be used for each of the scan topics.  This allows for scans from unreliable topics to be merged with reliable ones successfully.  Prior to this, attempts to do this would would fail silently.
2. Fix an issue whereby scans missing intensity values (e.g. as produced by [pointcloud_to_laserscan](https://github.com/ros-perception/pointcloud_to_laserscan) from a depth camera point cloud) break point cloud publication.

Example usage for 1:

```python
    scan_topics = LaunchConfiguration('scan_topics', default=["/lidar/scan", "/camera/scan"])
    qos_profiles = LaunchConfiguration('qos_profiles', default=["reliable", "besteffort"])
```

Thanks for the nice package!